### PR TITLE
feat(docker): use multi-stage builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,35 @@
 # pull official base image
-FROM python:3.10
+FROM python:3.10 AS base
 
 # set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
+ENV DJANGO_SETTINGS_MODULE=mysite.settings.base
 
 # set work directory
 WORKDIR /usr/src/app
 
 # install dependencies
 COPY ./requirements.txt .
-COPY ./requirements-dev.txt .
 
 RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
-RUN pip install -r requirements-dev.txt
 
 # copy project
 COPY . .
+
+RUN python manage.py collectstatic --no-input
+
+FROM base AS development
+ENV DJANGO_SETTINGS_MODULE=mysite.settings.dev
+
+COPY ./requirements-dev.txt .
+RUN pip install -r requirements-dev.txt
+
+CMD ["python", "manage.py", "runserver", "0.0.0.0:80"]
+
+FROM base AS production
+ENV DJANGO_SETTINGS_MODULE=mysite.settings.prod
+
+# Command to run Gunicorn
+CMD ["sh", "-c", "gunicorn mysite.wsgi:application --bind 0.0.0.0:80"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # pull official base image
-FROM python:3.10 AS base
+FROM python:3.13 AS base
 
 # set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -18,18 +18,27 @@ RUN pip install -r requirements.txt
 # copy project
 COPY . .
 
-RUN python manage.py collectstatic --no-input
-
+# ------------------------------
+# Development Configuration
+# ------------------------------
 FROM base AS development
 ENV DJANGO_SETTINGS_MODULE=mysite.settings.dev
 
+# Install the development dependencies
 COPY ./requirements-dev.txt .
 RUN pip install -r requirements-dev.txt
 
+# Run the Django development server
 CMD ["python", "manage.py", "runserver", "0.0.0.0:80"]
 
+# ------------------------------
+# Production Configuration
+# ------------------------------
 FROM base AS production
 ENV DJANGO_SETTINGS_MODULE=mysite.settings.prod
+
+# Collect static files to be served in production
+RUN python manage.py collectstatic --no-input
 
 # Command to run Gunicorn
 CMD ["sh", "-c", "gunicorn mysite.wsgi:application --bind 0.0.0.0:80"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 # pull official base image
 FROM python:3.13 AS base
 
+# For use docker-compose enviroment vars
+ARG DJANGO_ALLOWED_HOSTS
+
 # set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
+ENV DJANGO_ALLOWED_HOSTS=${DJANGO_ALLOWED_HOSTS}
 ENV DJANGO_SETTINGS_MODULE=mysite.settings.base
 
 # set work directory

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ help:
 
 
 start:
-	docker build -t mysite .
 	docker compose up
 
 stop:

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ help:
 
 
 start:
+	docker build --target development .
 	docker compose up
 
 stop:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,17 @@ version: '3.8'
 
 services:
   web:
-    build: .
+    build:
+      context: .
+      target: ${TARGET:-development}
     ports:
       - 80:80
     env_file:
       - ./.env
     depends_on:
       - db
+    volumes:
+      - ./:/usr/src/app
   db:
     image: postgres:15
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,17 +3,12 @@ version: '3.8'
 services:
   web:
     build: .
-    command: >
-+      sh -c "python manage.py collectstatic --no-input &&
-+      gunicorn mysite.wsgi:application --bind 0.0.0.0:80"
     ports:
       - 80:80
     env_file:
       - ./.env
     depends_on:
       - db
-    environment:
-      - DJANGO_SETTINGS_MODULE=mysite.settings.prod
   db:
     image: postgres:15
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: .
       target: ${TARGET:-development}
+      args:
+        DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS}
     ports:
       - 80:80
     env_file:

--- a/mysite/settings/dev.py
+++ b/mysite/settings/dev.py
@@ -3,6 +3,8 @@ from .base import *
 # Database
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases
 
+ALLOWED_HOSTS = ['localhost', '0.0.0.0', '127.0.0.1']
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
@@ -17,7 +19,7 @@ LOGGING = {
       'file': {
          'level': 'DEBUG',
          'class': 'logging.FileHandler',
-         'filename': 'tmp/debug.log',
+         'filename': '/tmp/debug.log',
       },
    },
    'loggers': {


### PR DESCRIPTION
Relates to #2 

The idea is to have a base image and then two distinct stages:
- development: installs specific libraries and runs Django in Debug mode.
- production: takes env variables to set up the database and uses gunicorn for serving the app.

I understand that Docker Compose uses the last built image, so I will modify the Makefile to create a make start command, along with options for dev or prod, to specify the associated stages.

As usual, nothing is working... yet!