### PR TITLE
draft: feat(env): add sample environment variables and update Makefile for development

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,5 @@
+POSTGRES_PASSWORD=postgres
+DJANGO_ALLOWED_HOSTS=*
+TARGET=development
+DEBUG=0
+SECRET_KEY=django-insecure-fruta

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ help:
 	@echo "migrations -- make migrations"
 	@echo "migrate -- migrate"
 
-
 start:
 	TARGET=development docker build .
 	docker compose up
@@ -32,12 +31,17 @@ pep8:
 
 test: pep8 only_test
 
+# attach to a new container
 webshell:
 	docker compose run --rm web bash
 
+# attach to running container
+ssh:
+	docker compose exec web bash
+
 dbshell:
 	docker compose exec db psql --username=my_site --dbname=my_site_prod
-	
+
 migrations:
 	docker compose run --rm web python3 manage.py makemigrations
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   web:
     build:
@@ -22,10 +20,7 @@ services:
     ports:
       - 5432:5432
     environment:
-      - PGUSER=my_user
-      - POSTGRES_DB=my_site_prod
-      - POSTGRES_USER=my_user
-      - POSTGRES_PASSWORD=my_site
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
 
 volumes:
   postgres_data:

--- a/mysite/settings/prod.py
+++ b/mysite/settings/prod.py
@@ -1,10 +1,12 @@
-from .base import *
+import os
+from .base import *  # noqa
 
 # Database
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases
 
-ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS").split(",")
+ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS", "").split(",")
 
+# Aca a reemplazar con dj-database-url
 DATABASES = {
     'default': {
         'ENGINE': os.environ.get('SQL_ENGINE'),


### PR DESCRIPTION
This PR needs some changes, the idea will be to have this in the base settings:

```python
import dj_database_url

DATABASES = {
    'default': dj_database_url.config(
        conn_max_age=600,
        conn_health_checks=True,
    ),
}
``` 

And in the .env and .env.sample have something like:

```
POSTGRES_PASSWORD=postgres
DATABASE_URL=postgres://postgres:postgres@db/postgres
```