### PR TITLE
feat(blog): add estimated reading time to posts

### DIFF
--- a/blog/models.py
+++ b/blog/models.py
@@ -88,6 +88,11 @@ class Post(Embeddable):
         self.published_at = timezone.now()
         self.save()
 
+    @property
+    def estimated_read_time(self) -> int:
+        word_count = len(self.text.split())
+        return max(1, round(word_count / 200))
+
     def __str__(self):
         return self.title
 

--- a/templates/blog/base.html
+++ b/templates/blog/base.html
@@ -43,7 +43,10 @@
             </p>
             
             <div class="mt-4 pt-3 border-top border-light-subtle d-flex justify-content-between align-items-center">
-              <small class="text-muted-custom" style="font-size: 0.75rem;"><i class="bi bi-calendar-event me-1"></i> {{ post.published_at|default:post.created_at|date:"F j, Y" }}</small>
+              <div class="d-flex align-items-center gap-3">
+                <small class="text-muted-custom" style="font-size: 0.75rem;"><i class="bi bi-calendar-event me-1"></i> {{ post.published_at|default:post.created_at|date:"F j, Y" }}</small>
+                <small class="text-muted-custom" style="font-size: 0.75rem;"><i class="bi bi-clock me-1"></i> {{ post.estimated_read_time }} min read</small>
+              </div>
               <span class="text-accent small fw-bold" style="font-size: 0.75rem;">Read <i class="bi bi-arrow-right"></i></span>
             </div>
           </div>

--- a/templates/blog/post.html
+++ b/templates/blog/post.html
@@ -11,6 +11,7 @@
       
       <div class="d-flex flex-wrap align-items-center gap-3 text-muted-custom mb-4 pb-3 border-bottom border-light-subtle">
         <span class="small"><i class="bi bi-calendar3 me-1"></i> {{ post.published_at|default:post.created_at|date:"F j, Y" }}</span>
+        <span class="small"><i class="bi bi-clock me-1"></i> {{ post.estimated_read_time }} min read</span>
         <span class="small"><i class="bi bi-person me-1"></i> By {{ post.author.get_full_name|default:post.author.username }}</span>
         
         {% if post.categories.all %}


### PR DESCRIPTION
Adds an estimated_read_time property to the Post model (assuming 200 WPM reading speed) and displays the calculated duration with a clock icon in the post list cards and the detailed post view.